### PR TITLE
Setup a config parsing for bot and server

### DIFF
--- a/.github/workflows/test_config.yml
+++ b/.github/workflows/test_config.yml
@@ -1,0 +1,20 @@
+name: test_config
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install toml
+      - name: Run test
+        run: |
+          cd test/
+          pytest test_config_parsing.py
+		

--- a/.github/workflows/test_config.yml
+++ b/.github/workflows/test_config.yml
@@ -16,5 +16,4 @@ jobs:
       - name: Run test
         run: |
           cd test/
-          pytest test_config_parsing.py
-		
+          pytest test_config_parsing.py		

--- a/.github/workflows/test_config.yml
+++ b/.github/workflows/test_config.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install toml
+          pip install toml pytest
       - name: Run test
         run: |
           cd test/

--- a/.github/workflows/test_config.yml
+++ b/.github/workflows/test_config.yml
@@ -15,5 +15,4 @@ jobs:
           pip install toml pytest
       - name: Run test
         run: |
-          cd test/
-          pytest test_config_parsing.py		
+          pytest test/test_config_parsing.py		

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .venv/
+*__pycache__/

--- a/main.py
+++ b/main.py
@@ -1,0 +1,35 @@
+import logging
+import tomllib
+import argparse
+
+logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+		    level=logging.INFO)
+
+logger = logging.getLogger(__name__)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-c", "--config", help="TOML file for bot token and server url")
+args = parser.parse_args()
+
+def parse_config(config_file):
+	with open(config_file, "rb") as f:
+		config = tomllib.load(f)
+
+	## get config for telegram bot
+	TOKEN = config["telegram-bot"]["API_TOKEN"]
+	CHAT_ID = config["telegram-bot"]["CHAT_ID"]
+	BOT_NAME = config["telegram-bot"]["NAME"]
+
+	## get config for target server
+	TARGET_URL = config["server"]["url"]
+
+	return TOKEN, CHAT_ID, TARGET_URL
+
+def main(args):
+	TARGET_URL, CHAT_ID, TARGET_URL = parse_config(args.config)
+
+
+
+if __name__ == "__main__":
+	main(args)
+	

--- a/main.py
+++ b/main.py
@@ -7,9 +7,10 @@ logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s
 
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-c", "--config", help="TOML file for bot token and server url")
-args = parser.parse_args()
+def create_parser(arg_list : list[str] | None = None):
+	parser = argparse.ArgumentParser()
+	parser.add_argument("-c", "--config", help="TOML file for bot token and server url")
+	return parser
 
 def parse_config(config_file):
 	with open(config_file, "rb") as f:
@@ -23,13 +24,14 @@ def parse_config(config_file):
 	## get config for target server
 	TARGET_URL = config["server"]["url"]
 
-	return TOKEN, CHAT_ID, TARGET_URL
+	return TOKEN, CHAT_ID, BOT_NAME, TARGET_URL
 
-def main(args):
-	TARGET_URL, CHAT_ID, TARGET_URL = parse_config(args.config)
+def main(arg_list : list[str] | None = None):
+	args = create_parser(arg_list)
+	TARGET_URL, CHAT_ID, BOT_NAME, TARGET_URL = parse_config(args.config)
 
 
 
 if __name__ == "__main__":
-	main(args)
+	main()
 	

--- a/test/test_config_parsing.py
+++ b/test/test_config_parsing.py
@@ -1,5 +1,5 @@
 import sys
-sys.path.append('../')
+sys.path.append('./')
 import unittest
 import tempfile
 import argparse

--- a/test/test_config_parsing.py
+++ b/test/test_config_parsing.py
@@ -1,0 +1,45 @@
+import sys
+sys.path.append('../')
+import unittest
+import tempfile
+import argparse
+import os
+from unittest.mock import patch
+from main import create_parser, parse_config
+import toml
+
+class TestConfigParser(unittest.TestCase):
+
+	def test_create_parser(self):
+		parser = create_parser()
+		self.assertIsInstance(parser, argparse.ArgumentParser)
+
+	def test_parse_config(self):
+		with tempfile.TemporaryDirectory(dir=".") as tmp:
+			path = os.path.join(tmp)
+			print(path)
+			data = {
+				"telegram-bot": {
+					"API_TOKEN": "token1234",
+					"CHAT_ID": "chat1234",
+					"NAME": "TestBot"
+				},
+				"server": {
+					"url": "https://example.com"
+				}
+			
+			}
+
+			tmp_file = path+"/test_config.toml"
+	
+			with open(tmp_file, "w") as test_toml:
+				toml.dump(data, test_toml)
+
+			result = parse_config(tmp_file)
+			self.assertEqual(result, ('token1234', 'chat1234', 'TestBot', 'https://example.com'))		
+
+	def tearDown(self):
+		 patch.stopall()
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
- Defined a parser in the `main.py` to configure the bot token, chat id, bot name and target server. 
- Added test to check that the parser works as expected.